### PR TITLE
Refactor command priority logic

### DIFF
--- a/bot/models/base_handlers.py
+++ b/bot/models/base_handlers.py
@@ -57,7 +57,7 @@ def stream_is_authenticated(func):
 
 
 class CommandPriority(enum.IntEnum):
-    TOP = 0
+    FIRST = 0
     DEFAULT = 1
     LAST = 2
 

--- a/bot/models/base_handlers.py
+++ b/bot/models/base_handlers.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from functools import wraps
 from typing import List, AsyncIterator, Optional
 import logging
+import enum
 
 from ..rp_bot.db import DB
 from ..rp_bot.ai import AI
@@ -55,6 +56,12 @@ def stream_is_authenticated(func):
     return wrapper
 
 
+class CommandPriority(enum.IntEnum):
+    TOP = 0
+    DEFAULT = 1
+    LAST = 2
+
+
 class BaseHandler(ABC):
     permissions: list = []
     streamable: bool = False
@@ -83,7 +90,7 @@ class BaseHandler(ABC):
 
 class BaseCommandHandler(BaseHandler, ABC):
     command: str = None
-    list_priority_order: int = 0
+    list_priority_order: CommandPriority = CommandPriority.DEFAULT
 
     async def get_localized_description(self) -> str:
         result = await self.localizer.get_command_response(

--- a/bot/models/base_handlers.py
+++ b/bot/models/base_handlers.py
@@ -59,7 +59,8 @@ def stream_is_authenticated(func):
 class CommandPriority(enum.IntEnum):
     FIRST = 0
     DEFAULT = 1
-    LAST = 2
+    ADMIN = 2
+    LAST = 3
 
 
 class BaseHandler(ABC):

--- a/bot/rp_bot/commands/addmode_handler.py
+++ b/bot/rp_bot/commands/addmode_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import AllowedUser, GroupAdmin, NotBanned
@@ -9,7 +9,7 @@ from ..auth import AllowedUser, GroupAdmin, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [AllowedUser, GroupAdmin, NotBanned]
     command = "addmode"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/ban_handler.py
+++ b/bot/rp_bot/commands/ban_handler.py
@@ -9,7 +9,7 @@ from ..auth import BotAdmin
 class CommandHandler(BaseCommandHandler):
     permissions = [BotAdmin]
     command = "ban"
-    list_priority_order = CommandPriority.DEFAULT
+    list_priority_order = CommandPriority.ADMIN
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/ban_handler.py
+++ b/bot/rp_bot/commands/ban_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import BotAdmin
@@ -9,7 +9,7 @@ from ..auth import BotAdmin
 class CommandHandler(BaseCommandHandler):
     permissions = [BotAdmin]
     command = "ban"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/clearfacts_handler.py
+++ b/bot/rp_bot/commands/clearfacts_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "clearfacts"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/conversationtracker_handler.py
+++ b/bot/rp_bot/commands/conversationtracker_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "conversationtracker"
-    list_priority_order = 3
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/deletemode_handler.py
+++ b/bot/rp_bot/commands/deletemode_handler.py
@@ -1,7 +1,7 @@
 from typing import List
 from collections import OrderedDict
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import KeyboardResponse, CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -10,7 +10,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "deletemode"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self,

--- a/bot/rp_bot/commands/fact_handler.py
+++ b/bot/rp_bot/commands/fact_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [AllowedUser, NotBanned]
     command = "fact"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/help_handler.py
+++ b/bot/rp_bot/commands/help_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 
@@ -8,7 +8,7 @@ from ...models.handlers_input import Person, Context, Message
 class CommandHandler(BaseCommandHandler):
     permissions = []
     command = "help"
-    list_priority_order = 4
+    list_priority_order = CommandPriority.LAST
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/introduce_handler.py
+++ b/bot/rp_bot/commands/introduce_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [AllowedUser, NotBanned]
     command = "introduce"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/language_handler.py
+++ b/bot/rp_bot/commands/language_handler.py
@@ -1,7 +1,7 @@
 from typing import List
 from collections import OrderedDict
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse, KeyboardResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -10,7 +10,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "language"
-    list_priority_order = 3
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/mode_handler.py
+++ b/bot/rp_bot/commands/mode_handler.py
@@ -1,7 +1,7 @@
 from typing import List
 from collections import OrderedDict
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import KeyboardResponse, CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -10,7 +10,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "mode"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/reset_handler.py
+++ b/bot/rp_bot/commands/reset_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "reset"
-    list_priority_order = 1
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/start_handler.py
+++ b/bot/rp_bot/commands/start_handler.py
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "start"
-    list_priority_order = CommandPriority.TOP
+    list_priority_order = CommandPriority.FIRST
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/start_handler.py
+++ b/bot/rp_bot/commands/start_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "start"
-    list_priority_order = 1
+    list_priority_order = CommandPriority.TOP
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/stop_handler.py
+++ b/bot/rp_bot/commands/stop_handler.py
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "stop"
-    list_priority_order = CommandPriority.TOP
+    list_priority_order = CommandPriority.FIRST
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/stop_handler.py
+++ b/bot/rp_bot/commands/stop_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import GroupAdmin, AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import GroupAdmin, AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [GroupAdmin, AllowedUser, NotBanned]
     command = "stop"
-    list_priority_order = 1
+    list_priority_order = CommandPriority.TOP
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/unban_handler.py
+++ b/bot/rp_bot/commands/unban_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import BotAdmin
@@ -9,7 +9,7 @@ from ..auth import BotAdmin
 class CommandHandler(BaseCommandHandler):
     permissions = [BotAdmin]
     command = "unban"
-    list_priority_order = 2
+    list_priority_order = CommandPriority.DEFAULT
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/unban_handler.py
+++ b/bot/rp_bot/commands/unban_handler.py
@@ -9,7 +9,7 @@ from ..auth import BotAdmin
 class CommandHandler(BaseCommandHandler):
     permissions = [BotAdmin]
     command = "unban"
-    list_priority_order = CommandPriority.DEFAULT
+    list_priority_order = CommandPriority.ADMIN
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]

--- a/bot/rp_bot/commands/usage_handler.py
+++ b/bot/rp_bot/commands/usage_handler.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from ...models.base_handlers import BaseCommandHandler
+from ...models.base_handlers import BaseCommandHandler, CommandPriority
 from ...models.handlers_response import CommandResponse
 from ...models.handlers_input import Person, Context, Message
 from ..auth import AllowedUser, NotBanned
@@ -9,7 +9,7 @@ from ..auth import AllowedUser, NotBanned
 class CommandHandler(BaseCommandHandler):
     permissions = [AllowedUser, NotBanned]
     command = "usage"
-    list_priority_order = 3
+    list_priority_order = CommandPriority.LAST
 
     async def get_command_response(
         self, person: Person, context: Context, message: Message, args: List[str]


### PR DESCRIPTION
Closes https://github.com/Flagro/TelegramRPBot/issues/24

This PR refactors the logic of command priorities to use `Enum` instead of just integers to introduce a more systematic approach for command ordering in the telegram commands list